### PR TITLE
Conversion of RGBA to RGB in order to save .jpg images

### DIFF
--- a/goompy/__init__.py
+++ b/goompy/__init__.py
@@ -73,6 +73,9 @@ def _grab_tile(lat, lon, zoom, maptype, _TILESIZE, sleeptime):
 
         result = urlopen(url).read()
         tile = PIL.Image.open(BytesIO(result))
+        # Some tiles are in mode `RGBA` and need to be converted
+        if tile.mode != 'RGB':
+            tile = tile.convert('RGB')
         if not os.path.exists('mapscache'):
             os.mkdir('mapscache')
         tile.save(filename)


### PR DESCRIPTION
Some of the static maps returned by the Google Maps API are in RGBA mode. These images cannot be saved as .jpg files.

**How to replicate this issue:**

* Delete the cache folder (`/mapscache/`)
* Run the `example.py` script
* Observe the following error message:
```
  File "/home/mhubrich/GooMPy/goompy/__init__.py", line 78, in _grab_tile
    tile.save(filename)
  File "/usr/local/lib/python2.7/dist-packages/PIL/Image.py", line 1930, in save
    save_handler(self, fp, filename)
  File "/usr/local/lib/python2.7/dist-packages/PIL/JpegImagePlugin.py", line 607, in _save
    raise IOError("cannot write mode %s as JPEG" % im.mode)
IOError: cannot write mode RGBA as JPEG
```